### PR TITLE
Use PyGObject bindings for Pango, and contextmanagers for drawing

### DIFF
--- a/papr/layouts/classic.py
+++ b/papr/layouts/classic.py
@@ -2,12 +2,15 @@
 # -*- coding: utf-8 -*-
 
 import math
-import cairo
-import pango
-import pangocairo
 import datetime
 import logging
+
+import cairo
+from gi.repository import Pango
+from gi.repository import PangoCairo
+
 from util import metrics
+from util import layout_draw
 
 
 def drawCalendar(env):
@@ -67,71 +70,55 @@ def drawCalendar(env):
 
 def drawText(cr, env, text, x, y, fontSize):
     cr.move_to(x, y)
-    pc = pangocairo.CairoContext(cr)
-    pc.set_antialias(cairo.ANTIALIAS_SUBPIXEL)
-
     # Number
-    layoutNumber = pc.create_layout()
-    fontNumber = pango.FontDescription("%s heavy %s" % (env.font, fontSize))
-    layoutNumber.set_font_description(fontNumber)
+    with layout_draw(cr) as layoutNumber:
+        fontNumber = Pango.FontDescription("%s heavy %s" % (env.font, fontSize))
+        layoutNumber.set_font_description(fontNumber)
 
-    layoutNumber.set_text(text.split()[0])
-    if env.color:
-        cr.set_source_rgb(0.6, 0, 0)
-    else:
-        cr.set_source_rgb(0, 0, 0)
-    pc.update_layout(layoutNumber)
-    pc.show_layout(layoutNumber)
+        layoutNumber.set_text(text.split()[0], -1)
+        if env.color:
+            cr.set_source_rgb(0.6, 0, 0)
+        else:
+            cr.set_source_rgb(0, 0, 0)
 
     # Day
     dimensions = layoutNumber.get_pixel_size()
     cr.move_to(x + dimensions[0] + fontSize / 2, y)
-    layoutDay = pc.create_layout()
-    fontDay = pango.FontDescription("%s %s" % (env.font, fontSize))
-    layoutDay.set_font_description(fontDay)
+    with layout_draw(cr) as layoutDay:
+        fontDay = Pango.FontDescription("%s %s" % (env.font, fontSize))
+        layoutDay.set_font_description(fontDay)
 
-    layoutDay.set_text(text.split()[1])
-    cr.set_source_rgb(0, 0, 0)
-    pc.update_layout(layoutDay)
-    pc.show_layout(layoutDay)
+        layoutDay.set_text(text.split()[1], -1)
+        cr.set_source_rgb(0, 0, 0)
 
 
 def drawMonthTitle(cr, env, x, y, width, height, dateObject):
-
     # preparing month string
     style = "%B"
     if(env.abbreviate_all):
         style = "%b"
     monthString = dateObject.strftime(style)
 
-    # preparing pango context and layout
-    pc = pangocairo.CairoContext(cr)
-    pc.set_antialias(cairo.ANTIALIAS_SUBPIXEL)
+    with layout_draw(cr) as layout:
+        layout.set_text(monthString, -1)
 
-    layout = pc.create_layout()
-    layout.set_text(monthString)
+        # calculate font size
+        fits = False
+        fontSize = 20
+        while not fits:
+            font = Pango.FontDescription("%s %s" % (env.font, fontSize))
+            layout.set_font_description(font)
+            logging.debug("font size: %s pixel_size: %s",
+                          fontSize, layout.get_pixel_size())
+            if(layout.get_pixel_size()[0] <= env.cell_width):
+                fits = True
+            else:
+                fontSize -= 1
 
-    # calculate font size
-    fits = False
-    fontSize = 20
-    while not fits:
-        font = pango.FontDescription("%s %s" % (env.font, fontSize))
-        layout.set_font_description(font)
-        logging.debug("font size: %s pixel_size: %s",
-                      fontSize, layout.get_pixel_size())
-        if(layout.get_pixel_size()[0] <= env.cell_width):
-            fits = True
-        else:
-            fontSize -= 1
-
-    # preparing cairo context
-    y += ((env.cell_height / 2) - (layout.get_pixel_size()[1] / 2))
-    cr.move_to(x, y)
-    cr.set_source_rgb(0, 0, 0)
-
-    # drawing pango text
-    pc.update_layout(layout)
-    pc.show_layout(layout)
+        # preparing cairo context
+        y += ((env.cell_height / 2) - (layout.get_pixel_size()[1] / 2))
+        cr.move_to(x, y)
+        cr.set_source_rgb(0, 0, 0)
 
 
 def drawDay(cr, env, x, y, width, height, lineWidth, dateObject):

--- a/papr/layouts/column.py
+++ b/papr/layouts/column.py
@@ -2,12 +2,15 @@
 # -*- coding: utf-8 -*-
 
 import math
-import cairo
-import pango
-import pangocairo
 import datetime
 import logging
+
+import cairo
+from gi.repository import Pango
+from gi.repository import PangoCairo
+
 from util import metrics
+from util import layout_draw
 
 
 def drawCalendar(env):
@@ -56,27 +59,22 @@ def drawMonth(cr, env, date):
 
 def drawMonthTitle(cr, env, date):
     cr.save()
-    pc = pangocairo.CairoContext(cr)
-    pc.set_antialias(cairo.ANTIALIAS_SUBPIXEL)
-    layout = pc.create_layout()
-    font = pango.FontDescription("%s %s" % (env.font, env.font_size * 2))
-    layout.set_font_description(font)
+    with layout_draw(cr) as layout:
+        font = Pango.FontDescription("%s %s" % (env.font, env.font_size * 2))
+        layout.set_font_description(font)
 
-    # preparing month string
-    style = "%B"
-    if(env.abbreviate_all):
-        style = "%b"
-    monthString = date.strftime(style)
+        # preparing month string
+        style = "%B"
+        if(env.abbreviate_all):
+            style = "%b"
+        monthString = date.strftime(style)
 
-    layout.set_text(monthString)
-    xOffset = (env.column_width - layout.get_pixel_size()[0]) / 2
-    yOffset = (((env.row_height * 2) -
-                layout.get_pixel_size()[1]) / 2) + env.safety
+        layout.set_text(monthString, -1)
+        xOffset = (env.column_width - layout.get_pixel_size()[0]) / 2
+        yOffset = (((env.row_height * 2) -
+                    layout.get_pixel_size()[1]) / 2) + env.safety
 
-    cr.translate(xOffset, yOffset)
-
-    pc.update_layout(layout)
-    pc.show_layout(layout)
+        cr.translate(xOffset, yOffset)
     cr.restore()
 
 
@@ -100,20 +98,16 @@ def drawDay(cr, env, date):
     cr.stroke()
 
     # Text
-    pc = pangocairo.CairoContext(cr)
-    pc.set_antialias(cairo.ANTIALIAS_SUBPIXEL)
-    layout = pc.create_layout()
-    font = pango.FontDescription("%s %s" % (env.font, env.font_size))
-    layout.set_font_description(font)
+    with layout_draw(cr) as layout:
+        font = Pango.FontDescription("%s %s" % (env.font, env.font_size))
+        layout.set_font_description(font)
 
-    style = "%A"
-    if(env.abbreviate or env.abbreviate_all):
-        style = "%a"
-    dayString = "%s %s" % (date.day, date.strftime(style))
-    layout.set_text(dayString)
+        style = "%A"
+        if(env.abbreviate or env.abbreviate_all):
+            style = "%a"
+        dayString = "%s %s" % (date.day, date.strftime(style))
+        layout.set_text(dayString, -1)
 
-    yOffset = (env.row_height - (layout.get_pixel_size()[1])) / 2
-    cr.translate(env.font_size / 2, yOffset)
-    pc.update_layout(layout)
-    pc.show_layout(layout)
+        yOffset = (env.row_height - (layout.get_pixel_size()[1])) / 2
+        cr.translate(env.font_size / 2, yOffset)
     cr.restore()

--- a/papr/layouts/column.py
+++ b/papr/layouts/column.py
@@ -10,7 +10,7 @@ from gi.repository import Pango
 from gi.repository import PangoCairo
 
 from util import metrics
-from util import layout_draw
+from util import drawing
 
 
 def drawCalendar(env):
@@ -40,74 +40,70 @@ def drawMonth(cr, env, date):
 
     # Defining a one day timedelta object to increase the date object
     ONE_DAY = datetime.timedelta(days=1)
-    cr.save()
-    # artificial offset for layouting, later it will be the months title!
-    for columnNo in range(0, 4):  # Iterate over 4 Month. 4 Month fit on one page
-        # move on the page to draw next month
-        cr.save()
-        cr.translate(columnNo * env.column_width, 0)
-        drawMonthTitle(cr, env, date)
-        # for every day of the month
-        startingMonth = date.month
-        while date.month == startingMonth:
-            # increment date by one day
-            drawDay(cr, env, date)
-            date += ONE_DAY
-        cr.restore()
-    cr.restore()
+    with drawing.restoring_transform(cr):
+        # artificial offset for layouting, later it will be the months title!
+        for columnNo in range(0, 4):  # Iterate over 4 Month. 4 Month fit on one page
+            with drawing.restoring_transform(cr):
+                # move on the page to draw next month
+                cr.translate(columnNo * env.column_width, 0)
+                drawMonthTitle(cr, env, date)
+                # for every day of the month
+                startingMonth = date.month
+                while date.month == startingMonth:
+                    # increment date by one day
+                    drawDay(cr, env, date)
+                    date += ONE_DAY
 
 
 def drawMonthTitle(cr, env, date):
-    cr.save()
-    with layout_draw(cr) as layout:
-        font = Pango.FontDescription("%s %s" % (env.font, env.font_size * 2))
-        layout.set_font_description(font)
+    with drawing.restoring_transform(cr):
+        with drawing.layout(cr) as layout:
+            font = Pango.FontDescription("%s %s" % (env.font, env.font_size * 2))
+            layout.set_font_description(font)
 
-        # preparing month string
-        style = "%B"
-        if(env.abbreviate_all):
-            style = "%b"
-        monthString = date.strftime(style)
+            # preparing month string
+            style = "%B"
+            if(env.abbreviate_all):
+                style = "%b"
+            monthString = date.strftime(style)
 
-        layout.set_text(monthString, -1)
-        xOffset = (env.column_width - layout.get_pixel_size()[0]) / 2
-        yOffset = (((env.row_height * 2) -
-                    layout.get_pixel_size()[1]) / 2) + env.safety
+            layout.set_text(monthString, -1)
+            xOffset = (env.column_width - layout.get_pixel_size()[0]) / 2
+            yOffset = (((env.row_height * 2) -
+                        layout.get_pixel_size()[1]) / 2) + env.safety
 
-        cr.translate(xOffset, yOffset)
-    cr.restore()
+            cr.translate(xOffset, yOffset)
 
 
 def drawDay(cr, env, date):
-    cr.save()
-    yOffset = env.safety + (2 * env.row_height) + ((date.day - 1) * env.row_height)
-    if(date.day > 15):  # add folding margin for other half of the month
-        yOffset += 2 * env.safety
-    # translate to drawing point
-    cr.translate(env.safety, yOffset)
-    # fill box if weekend
-    if(date.isoweekday() >= 6):
-        cr.set_source_rgba(0.90, 0.90, 0.90, 1.0)
+    with drawing.restoring_transform(cr):
+        yOffset = env.safety + (2 * env.row_height) + ((date.day - 1) * env.row_height)
+        if(date.day > 15):  # add folding margin for other half of the month
+            yOffset += 2 * env.safety
+        # translate to drawing point
+        cr.translate(env.safety, yOffset)
+        # fill box if weekend
+        if(date.isoweekday() >= 6):
+            cr.set_source_rgba(0.90, 0.90, 0.90, 1.0)
+            cr.rectangle(0, 0, env.row_width, env.row_height)
+            cr.fill()
+
+        # stroke the box
+        cr.set_source_rgba(0, 0, 0, 1.0)
+        cr.set_line_width(env.line_width)
         cr.rectangle(0, 0, env.row_width, env.row_height)
-        cr.fill()
+        cr.stroke()
 
-    # stroke the box
-    cr.set_source_rgba(0, 0, 0, 1.0)
-    cr.set_line_width(env.line_width)
-    cr.rectangle(0, 0, env.row_width, env.row_height)
-    cr.stroke()
+        # Text
+        with drawing.layout(cr) as layout:
+            font = Pango.FontDescription("%s %s" % (env.font, env.font_size))
+            layout.set_font_description(font)
 
-    # Text
-    with layout_draw(cr) as layout:
-        font = Pango.FontDescription("%s %s" % (env.font, env.font_size))
-        layout.set_font_description(font)
+            style = "%A"
+            if(env.abbreviate or env.abbreviate_all):
+                style = "%a"
+            dayString = "%s %s" % (date.day, date.strftime(style))
+            layout.set_text(dayString, -1)
 
-        style = "%A"
-        if(env.abbreviate or env.abbreviate_all):
-            style = "%a"
-        dayString = "%s %s" % (date.day, date.strftime(style))
-        layout.set_text(dayString, -1)
-
-        yOffset = (env.row_height - (layout.get_pixel_size()[1])) / 2
-        cr.translate(env.font_size / 2, yOffset)
-    cr.restore()
+            yOffset = (env.row_height - (layout.get_pixel_size()[1])) / 2
+            cr.translate(env.font_size / 2, yOffset)

--- a/papr/layouts/oneyear.py
+++ b/papr/layouts/oneyear.py
@@ -10,7 +10,7 @@ from gi.repository import Pango
 from gi.repository import PangoCairo
 
 from util import metrics
-from util import layout_draw
+from util import drawing
 
 
 def drawCalendar(env):
@@ -42,97 +42,90 @@ def drawMonth(cr, env, date):
     # Defining a one day timedelta object to increase the date object
     ONE_DAY = datetime.timedelta(days=1)
     for columnNo in range(0, 12):  # Iterate over 4 Month. 4 Month fit on one page
-        # move on the page to draw next month
-        cr.save()
-        cr.translate(env.safety + (columnNo * env.row_width) +
-                     (columnNo * env.safety), 0)
-        drawMonthTitle(cr, env, date)
-        # for every day of the month
-        startingMonth = date.month
-        while date.month == startingMonth:
-            drawDay(cr, env, date)
-            # increment date by one day
-            date += ONE_DAY
-        cr.restore()
+        with drawing.restoring_transform(cr):
+            # move on the page to draw next month
+            cr.translate(env.safety + (columnNo * env.row_width) +
+                         (columnNo * env.safety), 0)
+            drawMonthTitle(cr, env, date)
+            # for every day of the month
+            startingMonth = date.month
+            while date.month == startingMonth:
+                drawDay(cr, env, date)
+                # increment date by one day
+                date += ONE_DAY
 
 
 def drawMonthTitle(cr, env, date):
-    cr.save()
-    with layout_draw(cr) as layout:
-        size = math.ceil(env.row_height * 0.9) # calculating font-size depending on the row height
-        font = Pango.FontDescription("%s %s" % (env.fontHeading, size))
-        layout.set_font_description(font)
+    with drawing.restoring_transform(cr):
+        with drawing.layout(cr) as layout:
+            size = math.ceil(env.row_height * 0.9) # calculating font-size depending on the row height
+            font = Pango.FontDescription("%s %s" % (env.fontHeading, size))
+            layout.set_font_description(font)
 
-        # preparing month string
-        style = "%b"
-        # TODO String is always abbreviated, adjust the font-size depending on the row width for all month titles!
-        # style = "%B"
-        # if(env.abbreviate_all):
-        #     style = "%b"
-        monthString = date.strftime(style)
+            # preparing month string
+            style = "%b"
+            # TODO String is always abbreviated, adjust the font-size depending on the row width for all month titles!
+            # style = "%B"
+            # if(env.abbreviate_all):
+            #     style = "%b"
+            monthString = date.strftime(style)
 
-        layout.set_text(monthString, -1)
-        xOffset = (env.row_width - layout.get_pixel_size()[0]) / 2
-        yOffset = (env.safety + (1.0 * env.row_height)) - \
-            layout.get_pixel_size()[1]
+            layout.set_text(monthString, -1)
+            xOffset = (env.row_width - layout.get_pixel_size()[0]) / 2
+            yOffset = (env.safety + (1.0 * env.row_height)) - \
+                layout.get_pixel_size()[1]
 
-        cr.translate(xOffset, yOffset)
-
-    cr.restore()
+            cr.translate(xOffset, yOffset)
 
 
 def drawDay(cr, env, date):
-    cr.save() # save matrix
+    with drawing.restoring_transform(cr):
+        yOffset = env.safety + \
+            ((date.day - 1) * env.row_height) + (1.0 * env.row_height)
 
-    yOffset = env.safety + \
-        ((date.day - 1) * env.row_height) + (1.0 * env.row_height)
+        # translate to drawing point top left corner
+        cr.translate(0.0, yOffset)
 
-    # translate to drawing point top left corner
-    cr.translate(0.0, yOffset)
+        # fill box if weekend
+        if(date.isoweekday() >= 6):
+            cr.set_source_rgba(0.90, 0.90, 0.90, 1.0)
+            cr.rectangle(0, 0, env.row_width, env.row_height)
+            cr.fill()
 
-    # fill box if weekend
-    if(date.isoweekday() >= 6):
-        cr.set_source_rgba(0.90, 0.90, 0.90, 1.0)
+        # stroke the box
+        cr.set_source_rgba(0, 0, 0, 1.0)
+        cr.set_line_width(env.line_width)
         cr.rectangle(0, 0, env.row_width, env.row_height)
-        cr.fill()
+        cr.stroke()
 
-    # stroke the box
-    cr.set_source_rgba(0, 0, 0, 1.0)
-    cr.set_line_width(env.line_width)
-    cr.rectangle(0, 0, env.row_width, env.row_height)
-    cr.stroke()
+        daySize = math.floor(env.row_height * 0.25)
+        numberSize = math.floor(env.row_height * 0.5)
+        yOffset = (env.row_height* 0.25) / 2
 
-    daySize = math.floor(env.row_height * 0.25)
-    numberSize = math.floor(env.row_height * 0.5)
-    yOffset = (env.row_height* 0.25) / 2
+        dayFont = Pango.FontDescription("%s %s" % (env.font, daySize)) # day text is way smaller than number
+        numberFont = Pango.FontDescription("%s %s" % (env.font, numberSize))
 
-    dayFont = Pango.FontDescription("%s %s" % (env.font, daySize)) # day text is way smaller than number
-    numberFont = Pango.FontDescription("%s %s" % (env.font, numberSize))
+        style = "%a" # by default abbreviated because need of space!
+        # if(env.abbreviate or env.abbreviate_all):
+        #     style = "%a"
+        weekdayString = "%s" % (date.strftime(style))
 
-    style = "%a" # by default abbreviated because need of space!
-    # if(env.abbreviate or env.abbreviate_all):
-    #     style = "%a"
-    weekdayString = "%s" % (date.strftime(style))
+        with drawing.restoring_transform(cr):
+            with drawing.layout(cr) as numberLayout:
+                numberLayout.set_font_description(numberFont)
+                numberLayout.set_text("%s" % date.day, -1) # Number
 
-    with layout_draw(cr) as numberLayout:
-        numberLayout.set_font_description(numberFont)
-        numberLayout.set_text("%s" % date.day, -1) # Number
+                xOffset = math.ceil((env.row_width / 8)  - (numberLayout.get_pixel_size()[0] / 2))
+                # yOffset = math.floor((env.row_height - numberSize - daySize - (daySize/2)) / 2)
+                numberOffset = yOffset + ((numberSize - numberLayout.get_pixel_size()[1])/2)
+                cr.translate(xOffset, numberOffset)
 
-        cr.save()
-        xOffset = math.ceil((env.row_width / 8)  - (numberLayout.get_pixel_size()[0] / 2))
-        # yOffset = math.floor((env.row_height - numberSize - daySize - (daySize/2)) / 2)
-        numberOffset = yOffset + ((numberSize - numberLayout.get_pixel_size()[1])/2)
-        cr.translate(xOffset, numberOffset)
-    cr.restore()
+        with drawing.restoring_transform(cr):
+            with drawing.layout(cr) as dayLayout:
+                dayLayout.set_font_description(dayFont)
+                dayLayout.set_text(weekdayString, -1) # Weekday
 
-    with layout_draw(cr) as dayLayout:
-        dayLayout.set_font_description(dayFont)
-        dayLayout.set_text(weekdayString, -1) # Weekday
+                xOffset = math.ceil((env.row_width / 8)  - (dayLayout.get_pixel_size()[0] / 2))
+                yOffset = env.row_height - yOffset - daySize
+                cr.translate(xOffset, yOffset)
 
-        cr.save()
-        xOffset = math.ceil((env.row_width / 8)  - (dayLayout.get_pixel_size()[0] / 2))
-        yOffset = env.row_height - yOffset - daySize
-        cr.translate(xOffset, yOffset)
-    cr.restore()
-
-    cr.restore() # restore matrix

--- a/papr/papr.py
+++ b/papr/papr.py
@@ -3,10 +3,14 @@
 
 import sys
 import locale
-import pangocairo
 import argparse
 import datetime
 import logging
+
+import gi
+gi.require_version('PangoCairo', '1.0')
+from gi.repository import PangoCairo
+
 from util import metrics
 from layouts import classic
 from layouts import column
@@ -32,7 +36,7 @@ def main():
     parser.add_argument("-c", "--color", action="store_true",
                         help="color date numbers", default=False)
 
-    font_map = pangocairo.cairo_font_map_get_default()
+    font_map = PangoCairo.font_map_get_default()
     parser.add_argument("-f", "--fonts", choices=[f.get_name(
     ) for f in font_map.list_families()], help="choose which font to use", default="Sans", metavar="FONT", nargs="+")
 

--- a/papr/util/__init__.py
+++ b/papr/util/__init__.py
@@ -1,9 +1,0 @@
-from gi.repository import PangoCairo
-from contextlib import contextmanager
-
-@contextmanager
-def layout_draw(cr):
-    layout = PangoCairo.create_layout(cr)
-    yield layout
-    PangoCairo.update_layout(cr, layout)
-    PangoCairo.show_layout(cr, layout)

--- a/papr/util/__init__.py
+++ b/papr/util/__init__.py
@@ -1,0 +1,9 @@
+from gi.repository import PangoCairo
+from contextlib import contextmanager
+
+@contextmanager
+def layout_draw(cr):
+    layout = PangoCairo.create_layout(cr)
+    yield layout
+    PangoCairo.update_layout(cr, layout)
+    PangoCairo.show_layout(cr, layout)

--- a/papr/util/drawing.py
+++ b/papr/util/drawing.py
@@ -1,0 +1,15 @@
+from gi.repository import PangoCairo
+from contextlib import contextmanager
+
+@contextmanager
+def layout(cr):
+    layout = PangoCairo.create_layout(cr)
+    yield layout
+    PangoCairo.update_layout(cr, layout)
+    PangoCairo.show_layout(cr, layout)
+
+@contextmanager
+def restoring_transform(cr):
+    cr.save()
+    yield
+    cr.restore()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pycairo==1.8.10
+pygobject>=2.28.0


### PR DESCRIPTION
The current master implicitly depends on PyGTK (it's not specified in requirements.txt) for Pango and PangoCairo. According to PyGTK's site,

> New users wishing to develop Python applications using GTK+ are recommended to use the GObject-Introspection features available in PyGObject.

This is a set of changes to use the new bindings. That also makes the application compatible with Python 3.


Another small change, that I made together with this one, is using context managers for PangoCairo layouting and Cairo save/restore.