### PR TITLE
feat: implements a dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ Or using uv (from the project directory):
 uv run papr -y 2023 -m 2 -f='Avenir Next' -p A3 oneyear
 ```
 
+## Development mode (uv only)
+
+For development, watch for file changes and automatically regenerate the PDF (like `npm run dev`):
+
+```sh
+# First, sync with dev dependencies (like npm install)
+uv sync
+
+# Then run in watch mode
+uv run python -m papr.dev -y 2023 -m 2 -f='Avenir Next' -p A3 oneyear
+```
+
+The dev mode will:
+- Run the command once immediately
+- Watch for changes in the papr source files
+- Automatically rerun when you save changes
+- Clear the console between runs for clean output
+
+Press `Ctrl+C` to stop watching.
+
+**Note:** This feature is only available when developing with uv and won't be included in Homebrew installations.
+
 ```sh
 usage: papr.py [-h] [-o OUT] [-A] [-a] [-b BRAND] [-c] [-f FONT [FONT ...]]
                    [-l LOCALE] [-m MONTH] [-y YEAR]

--- a/papr/dev.py
+++ b/papr/dev.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+import subprocess
+from pathlib import Path
+from watchfiles import watch
+
+def main():
+    """
+    Dev mode: Watch for file changes and rerun papr command.
+    Usage: papr-dev [same arguments as papr]
+    """
+    # Get the papr source directory
+    papr_dir = Path(__file__).parent
+
+    # Get the command arguments (everything after papr-dev)
+    papr_args = sys.argv[1:]
+
+    if not papr_args:
+        print("Error: Please provide papr arguments")
+        print("Usage: papr-dev [papr arguments]")
+        print("Example: papr-dev -y 2023 -m 2 -f='Avenir Next' -p A3 oneyear")
+        sys.exit(1)
+
+    # Build the command to run
+    cmd = [sys.executable, "-m", "papr.papr"] + papr_args
+
+    print(f"🔧 Dev mode started")
+    print(f"📂 Watching: {papr_dir}")
+    print(f"🚀 Running: papr {' '.join(papr_args)}")
+    print("=" * 60)
+
+    def run_command():
+        """Run the papr command"""
+        try:
+            result = subprocess.run(cmd, check=False)
+            if result.returncode == 0:
+                print("\n✅ Command completed successfully")
+            else:
+                print(f"\n❌ Command failed with exit code {result.returncode}")
+        except Exception as e:
+            print(f"\n❌ Error running command: {e}")
+
+    # Run once initially
+    run_command()
+
+    print("\n👀 Watching for changes... (Press Ctrl+C to stop)")
+    print("=" * 60)
+
+    # Watch for changes and rerun
+    try:
+        for changes in watch(papr_dir, watch_filter=lambda change, path: path.endswith('.py')):
+            # Clear screen for clean output
+            os.system('clear' if os.name == 'posix' else 'cls')
+
+            print("🔄 Files changed, rerunning...")
+            for change_type, path in changes:
+                print(f"  {change_type.name}: {Path(path).relative_to(papr_dir.parent)}")
+            print("=" * 60)
+
+            run_command()
+
+            print("\n👀 Watching for changes... (Press Ctrl+C to stop)")
+            print("=" * 60)
+    except KeyboardInterrupt:
+        print("\n\n👋 Dev mode stopped")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a uv-only development watch mode to auto-regenerate PDFs on source changes.
> 
> - New `papr/dev.py` module runs `papr` via `python -m papr.dev ...`, watches `papr` `.py` files with `watchfiles`, clears console, runs once initially, and reruns on change
> - README: adds **Development mode (uv only)** section with `uv sync` and `uv run python -m papr.dev ...` instructions and notes it's not included in Homebrew installs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41994d92bcfdf0caeb0a8e802943c2e70557168c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->